### PR TITLE
added lowercase version of payload.Message

### DIFF
--- a/src/utils/request-api.js
+++ b/src/utils/request-api.js
@@ -21,7 +21,7 @@ function parseError (res, cb) {
 
     if (payload) {
       error.code = payload.Code
-      error.message = payload.Message || payload.toString()
+      error.message = payload.message || payload.Message ||payload.toString()
       error.type = payload.Type
     }
     cb(error)

--- a/src/utils/request-api.js
+++ b/src/utils/request-api.js
@@ -20,7 +20,7 @@ function parseError (res, cb) {
     }
 
     if (payload) {
-      error.code = payload.Code
+      error.code = payload.code || payload.Code
       error.message = payload.message || payload.Message ||payload.toString()
     }
     cb(error)

--- a/src/utils/request-api.js
+++ b/src/utils/request-api.js
@@ -22,7 +22,6 @@ function parseError (res, cb) {
     if (payload) {
       error.code = payload.Code
       error.message = payload.message || payload.Message ||payload.toString()
-      error.type = payload.Type
     }
     cb(error)
   })


### PR DESCRIPTION
For some reason, when passing in an invalid CID: the payload returned is: 
```
{
  "code": 400,
  "message": "error decoding Cid: selected encoding not supported"
}
```

Because the request-api expects an uppercase "Message" this causes the error message to look like:

```
{
   message: "[object Object]"
}
```

adding this extra case fixes this issue and correctly returns the error message